### PR TITLE
Use lids for tracking

### DIFF
--- a/crnk-operations/src/main/java/io/crnk/operations/Operation.java
+++ b/crnk-operations/src/main/java/io/crnk/operations/Operation.java
@@ -1,6 +1,5 @@
 package io.crnk.operations;
 
-import io.crnk.core.engine.document.Resource;
 import io.crnk.core.engine.internal.utils.CompareUtils;
 import io.crnk.operations.document.OperationResource;
 

--- a/crnk-operations/src/main/java/io/crnk/operations/internal/OperationLidUtils.java
+++ b/crnk-operations/src/main/java/io/crnk/operations/internal/OperationLidUtils.java
@@ -21,21 +21,21 @@ public final class OperationLidUtils {
 		if (operations != null && !operations.isEmpty()) {
 			operations.stream()
 					.map(OrderedOperation::getOperation)
-					.filter(o -> o.getOp().equalsIgnoreCase(HttpMethod.POST.name()))
+					.filter(o -> isPostOperation(o) && isUsingLid(o))
 					.forEach(o -> {
 						Set<String> orDefault = map.getOrDefault(o.getValue().getType(), new HashSet<>());
-						orDefault.add(o.getValue().getId());
+						orDefault.add(o.getValue().getLid());
 						map.put(o.getValue().getType(), orDefault);
 					});
 		}
 		return map;
 	}
 
-	public static boolean hasLid(Map<String, Set<String>> lidsPerType, String type, String id) {
-		if (StringUtils.isBlank(type) || StringUtils.isBlank(id) || isEmpty(lidsPerType)) {
+	public static boolean containsLid(Map<String, Set<String>> lidsPerType, String type, String lid) {
+		if (StringUtils.isBlank(type) || StringUtils.isBlank(lid) || isEmpty(lidsPerType)) {
 			return false;
 		}
-		return lidsPerType.containsKey(type) && lidsPerType.get(type).contains(id);
+		return lidsPerType.containsKey(type) && lidsPerType.get(type).contains(lid);
 	}
 
 	public static void resolveLidsForRelations(
@@ -64,13 +64,21 @@ public final class OperationLidUtils {
 			Map<String, String> lidPerId,
 			ResourceIdentifier resourceIdentifier
 	) {
-		if (hasLid(lidsPerType, resourceIdentifier.getType(), resourceIdentifier.getId())) {
+		if (containsLid(lidsPerType, resourceIdentifier.getType(), resourceIdentifier.getId())) {
 			resourceIdentifier.setId(lidPerId.get(resourceIdentifier.getId()));
 		}
 	}
 
 	private static <T, K> boolean isEmpty(Map<T, K> col) {
 		return col == null || col.isEmpty();
+	}
+
+	private static boolean isUsingLid(io.crnk.operations.Operation o) {
+		return o.getValue() != null && StringUtils.isBlank(o.getValue().getId()) && !StringUtils.isBlank(o.getValue().getLid());
+	}
+
+	private static boolean isPostOperation(io.crnk.operations.Operation o) {
+		return o.getOp().equalsIgnoreCase(HttpMethod.POST.name());
 	}
 
 }

--- a/crnk-operations/src/main/java/io/crnk/operations/server/OperationsModule.java
+++ b/crnk-operations/src/main/java/io/crnk/operations/server/OperationsModule.java
@@ -15,6 +15,7 @@ import io.crnk.core.engine.internal.dispatcher.path.PathBuilder;
 import io.crnk.core.engine.internal.dispatcher.path.ResourcePath;
 import io.crnk.core.engine.internal.http.JsonApiRequestProcessorHelper;
 import io.crnk.core.engine.internal.utils.PreconditionUtil;
+import io.crnk.core.engine.internal.utils.StringUtils;
 import io.crnk.core.engine.parser.TypeParser;
 import io.crnk.core.engine.query.QueryContext;
 import io.crnk.core.engine.registry.RegistryEntry;
@@ -315,7 +316,7 @@ public class OperationsModule implements Module {
                 Response response = requestDispatcher.dispatchRequest(path, method, parameters, requestBody);
                 boolean success = response.getHttpStatus() < 400;
 
-				if (success && OperationLidUtils.hasLid(lidsPerType, operation.getValue().getType(), operation.getValue().getId())) {
+				if (success && !StringUtils.isBlank(operation.getValue().getLid())) {
 					trackLids(lidPerId, operation.getValue(), response.getDocument().getData());
 				}
 
@@ -338,12 +339,12 @@ public class OperationsModule implements Module {
 
 	private static void trackLids(
 			Map<String, String> lidPerId,
-			Resource resource,
+			OperationResource resource,
 			Nullable<Object> responseData
 	) {
 		if (responseData.isPresent() && responseData.get() instanceof Resource) {
 			Resource r = (Resource) responseData.get();
-			lidPerId.put(resource.getId(), r.getId());
+			lidPerId.put(resource.getLid(), r.getId());
 		}
 	}
 

--- a/crnk-operations/src/main/java/io/crnk/operations/server/OperationsRequestProcessor.java
+++ b/crnk-operations/src/main/java/io/crnk/operations/server/OperationsRequestProcessor.java
@@ -41,15 +41,6 @@ public class OperationsRequestProcessor implements HttpRequestProcessor {
             try {
                 List<Operation> operations = Arrays.asList(mapper.readValue(context.getRequestBody(), Operation[].class));
 
-                // Use Local Id if present
-				if (!operations.isEmpty()) {
-					operations.forEach(operation -> {
-						if (!StringUtils.isBlank(operation.getValue().getLid())) {
-							operation.getValue().setId(operation.getValue().getLid());
-						}
-					});
-				}
-
                 QueryContext queryContext = context.getQueryContext();
                 List<OperationResponse> responses = operationsModule.apply(operations, queryContext);
 


### PR DESCRIPTION
Here we tighten up the implementation to use lids as the sole keyword for referencing a transient entity.

```
[
	{
		"op": "POST",
		"path": "managed-attribute",
		"value": {
			"type": "managed-attribute",
			"lid": "deee51e7-cdee-4052-812e-85020f72ce83",
			"attributes": {
				"name": "TestAttribute",
				"managedAttributeType": "STRING",
				"managedAttributeComponent": "COLLECTING_EVENT"
			}
		}
	},
	{
		"op": "POST",
		"path": "collecting-event",
		"value": {
			"type": "collecting-event",
			"lid": "f5a64e28-2eab-4143-aec5-3450ba3e2898",
			"attributes": {
				"createdBy": "fo",
				"startEventDateTime": "1998",
				"endEventDateTime": "2020-01",
				"group": "cnc"
			}
		}
	},
	{
		"op": "POST",
		"path": "event-managed-attribute",
		"value": {
			"type": "event-managed-attribute",
			"id": "aa2b99ed-de06-4f5f-9ca6-98182a5edac5",
			"attributes": {
				"assignedValue": "t"
			},
			"relationships": {
				"event": {
					"data": {
						"type": "collecting-event",
						"id": "f5a64e28-2eab-4143-aec5-3450ba3e2898"
					}
				},
				"managedAttribute": {
					"data": {
						"type": "managed-attribute",
						"id": "deee51e7-cdee-4052-812e-85020f72ce83"
					}
				}
			}
		}
	}
]
```